### PR TITLE
Update github checkout action from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: build-push
       env:
         DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
Fixes build failures due to deprecation of checkout action v3