### PR TITLE
fix: Update package.json with correct release info

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,4 @@
+{
+  "branches": ["main"],
+  "plugins": ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/github']
+}

--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,4 @@
 {
-  "branches": ["main"],
+  "branches": ["main", "alpha"],
   "plugins": ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/github']
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "app.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appsody/stacks.git",
+    "url": "https://github.com/nastacio/github-board-sync.git",
     "directory": "incubator/nodejs-express/templates/simple"
   },
   "scripts": {


### PR DESCRIPTION
package.json had the wrong repo URL, which was preventing the semantic-release tool from generating new releases.